### PR TITLE
Opt out of the new UI experience since it breaks the browser automation

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -110,11 +110,17 @@ module.exports = {
         if (status !== "success") throw new CLIError("Failed to load Azure login page!");
 
         // Opt out of the new UI, if presented
-        await page.evaluate(function () {
+        const newUI = await page.evaluate(function () {
             if (document.getElementById('uxOptOutLink')) {
                 document.getElementById('uxOptOutLink').click();
+                return true;
             }
+            return false;
         });
+
+        // Switching back to the classic UI causes a page load - wait briefly for it to finish (_waitForPageToLoadAsync hangs if used here)
+        if (newUI)
+            await Bluebird.delay(2000);
 
         page.on("onLoadFinished", status => {
             debug("onLoadFinished event triggered");

--- a/lib/login.js
+++ b/lib/login.js
@@ -109,6 +109,13 @@ module.exports = {
         debug("Page opened");
         if (status !== "success") throw new CLIError("Failed to load Azure login page!");
 
+        // Opt out of the new UI, if presented
+        await page.evaluate(function () {
+            if (document.getElementById('uxOptOutLink')) {
+                document.getElementById('uxOptOutLink').click();
+            }
+        });
+
         page.on("onLoadFinished", status => {
             debug("onLoadFinished event triggered");
             


### PR DESCRIPTION
Microsoft recently released an updated UI, but left a backward-compatibility link. Click that link, if it exists, to continue using the working automation.