### PR TITLE
Handle alternate ADFS version

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -157,9 +157,16 @@ module.exports = {
 
         debug("Populating and submitting login form on the ADFS login screen");
 
+        // There seems to be at least 2 variants of ADFS
         const newUrl = await this._page.evaluate(function (username, password) {
-            document.forms[0].UserName.value = username;
-            document.forms[0].Password.value = password;
+            if (document.forms[0].userNameInput)
+                document.forms[0].userNameInput.value = username;
+            if (document.forms[0].passwordInput)
+                document.forms[0].passwordInput.value = password;
+            if (document.forms[0].UserName)
+                document.forms[0].UserName.value = username;
+            if (document.forms[0].Password)
+                document.forms[0].Password.value = password;
             document.forms[0].submit();
         }, credentials.username, credentials.password);
 
@@ -213,6 +220,10 @@ module.exports = {
             tfaResult = content("#tfa_results_container>div").filter(function () {
                 return content(this).css('display') === 'block';
             });
+            // Alternative MFA message
+            if (!tfaResult.length) {
+                tfaResult = content("#mfaGreetingDescription");
+            }
 
             if (tfaResult.length) break;
 
@@ -225,8 +236,12 @@ module.exports = {
         const tfaMessage = tfaResult.text().trim();
         if (tfaMessage) console.log(tfaMessage);
 
+        let quirkyMFA = false;
+
         // Check if verification code is needed.
-        if (tfaMessage && tfaMessage.toLowerCase().indexOf("verification code") >= 0) {
+        if (tfaMessage &&
+            (tfaMessage.toLowerCase().indexOf("verification code") >= 0 ||
+            tfaMessage.toLowerCase().indexOf("additional information to verify your account") >= 0)) {
             debug("Prompting user for verification code");
             const answers = await inquirer.prompt([{
                 name: "verificationCode",
@@ -234,22 +249,53 @@ module.exports = {
             }]);
 
             debug('Received code. Populating form in PhantomJS');
-            const errorMessage = await this._page.evaluate(function (verificationCode) {
-                document.getElementById("tfa_code_inputtext").value = verificationCode;
-                document.getElementById("tfa_signin_button").click();
+            let errorMessage = await this._page.evaluate(function (verificationCode) {
+                if (document.getElementById("tfa_code_inputtext")) {
+                    document.getElementById("tfa_code_inputtext").value = verificationCode;
+                    document.getElementById("tfa_signin_button").click();
 
-                // Error handling is done client-side, so check to see if the error message displays.
-                var errorBox = document.getElementById('tfa_client_side_error_text');
-                if (errorBox.style.display === "block") {
-                    return errorBox.textContent.trim();
+                    // Error handling is done client-side, so check to see if the error message displays.
+                    var errorBox = document.getElementById('tfa_client_side_error_text');
+                    if (errorBox.style.display === "block") {
+                        return errorBox.textContent.trim();
+                    }
+                }
+                if (document.getElementById("security_code")) {
+                    document.getElementById("security_code").value = verificationCode;
+                    document.getElementById("continueButton").click();
+                    // This version of ADFS submits form instead of returning inline - let it load and check the result below
+                    return "WAIT_FOR_SUBMIT";
                 }
             }, answers.verificationCode);
+
+            if (errorMessage == "WAIT_FOR_SUBMIT") {
+                quirkyMFA = true;
+                debug("Waiting for MFA page to load to check for error");
+                await this._waitForPageToLoadAsync();
+                errorMessage = await this._page.evaluate(function() {
+                    if (document.querySelector("#customAuthArea>p")) {
+                        return document.querySelector("#customAuthArea>p").textContent.trim();
+                    }
+                    return "";
+                });
+            }
 
             if (errorMessage) throw new CLIError(`Login failed: ${errorMessage}`);
         }
 
         await this._waitForPageToLoadAsync();
-
+        
+        if (quirkyMFA) {
+            // There's an interim ADFS page that uses Javascript to make a final submission
+            //debug("ADFS interim page content", await this._page.property("content"));
+            debug("Submitting interim ADFS page");
+            this._page.evaluate(function () {
+                document.forms[0].submit();
+            });
+            
+            await this._waitForPageToLoadAsync();
+        }
+    
         debug("Fetching page content");
         contentText = await this._page.property("content");
 


### PR DESCRIPTION
There are apparently more than one way for ADFS to skin the MFA cat, so this PR adds logic to detect one known alternate and handle its quirks.

(For the version of ADFS this is tested against, requires the PR from my classic_ui branch to fully function, but I wanted to keep the topics separate for easier review)